### PR TITLE
Make auto hiding scroll buttons the default behavior

### DIFF
--- a/docs/pages/components/tab-group.md
+++ b/docs/pages/components/tab-group.md
@@ -411,12 +411,12 @@ const App = () => (
 );
 ```
 
-### Auto hide scroll controls
+### Fixed scroll controls
 
-When tabs are scrolled all the way to one side, the scroll button on that side can't be clicked. Add the `auto-hide-scroll-buttons` attribute to the tab group to hide the effected button in that case.
+When tabs are scrolled all the way to one side, the scroll button on that side can't be clicked. Set the `fixed-scroll-controls` attribute to keep the effected button visible in that case.
 
 ```html:preview
-<sl-tab-group auto-hide-scroll-buttons>
+<sl-tab-group fixed-scroll-controls>
   <sl-tab slot="nav" panel="tab-1">Tab 1</sl-tab>
   <sl-tab slot="nav" panel="tab-2">Tab 2</sl-tab>
   <sl-tab slot="nav" panel="tab-3">Tab 3</sl-tab>

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -14,7 +14,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 
 ## Next
 
-- Added ability to auto hide scroll buttons for `<sl-tab-group>` when scroll button is not clickable. Added the `fix-scroll-control` property to optionally prevent this behavior. [#2128]
+- Scroll buttons for `<sl-tab-group>` auto hide when they are not clickable. The `fixed-scroll-controls` attribute can be included to prevent this behavior. [#2128]
 - Added support for using `<sl-dropdown>` in `<sl-breadcrumb-item>` default slot [#2015]
 - Fixed a bug that caused errors to show in the console when components disconnect before before `firstUpdated()` executes [#2127]
 

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -14,7 +14,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 
 ## Next
 
-- Added ability to auto hide scroll buttons for `<sl-tab-group>` when scroll button is not clickable. [#2128]
+- Added ability to auto hide scroll buttons for `<sl-tab-group>` when scroll button is not clickable. Added the `fix-scroll-control` property to optionally prevent this behavior. [#2128]
 - Added support for using `<sl-dropdown>` in `<sl-breadcrumb-item>` default slot [#2015]
 - Fixed a bug that caused errors to show in the console when components disconnect before before `firstUpdated()` executes [#2127]
 

--- a/docs/pages/resources/changelog.md
+++ b/docs/pages/resources/changelog.md
@@ -14,7 +14,7 @@ New versions of Shoelace are released as-needed and generally occur when a criti
 
 ## Next
 
-- Added ability to auto hide scroll buttons for `<sl-tab-group>` when scroll button is not clickable by adding the `auto-hide-scroll-buttons` attribute. [#2128]
+- Added ability to auto hide scroll buttons for `<sl-tab-group>` when scroll button is not clickable. [#2128]
 - Added support for using `<sl-dropdown>` in `<sl-breadcrumb-item>` default slot [#2015]
 - Fixed a bug that caused errors to show in the console when components disconnect before before `firstUpdated()` executes [#2127]
 

--- a/src/components/tab-group/tab-group.component.ts
+++ b/src/components/tab-group/tab-group.component.ts
@@ -76,8 +76,8 @@ export default class SlTabGroup extends ShoelaceElement {
   /** Disables the scroll arrows that appear when tabs overflow. */
   @property({ attribute: 'no-scroll-controls', type: Boolean }) noScrollControls = false;
 
-  /** Hide scroll buttons when inactive. */
-  @property({ attribute: 'auto-hide-scroll-buttons', type: Boolean }) autoHideScrollButtons = true;
+  /** Prevent scroll buttons from being hidden when inactive. */
+  @property({ attribute: 'fixed-scroll-controls', type: Boolean }) fixedScrollControls = false;
 
   connectedCallback() {
     const whenAllDefined = Promise.all([
@@ -380,7 +380,7 @@ export default class SlTabGroup extends ShoelaceElement {
 
   @eventOptions({ passive: true })
   private updateScrollButtons() {
-    if (this.hasScrollControls && this.autoHideScrollButtons) {
+    if (this.hasScrollControls && !this.fixedScrollControls) {
       this.shouldHideScrollStartButton = this.scrollFromStart() <= this.scrollOffset;
       this.shouldHideScrollEndButton = this.isScrolledToEnd();
     }


### PR DESCRIPTION
Make auto hiding scroll buttons the default behavior for <sl-tab-group>